### PR TITLE
hubot-sm new feature implement

### DIFF
--- a/lib/SMUtil.coffee
+++ b/lib/SMUtil.coffee
@@ -82,24 +82,24 @@ class IncidentMangement extends RestMethod
     @incident_id = null
 
   get: (id, callback) ->
-    url = "#{@baseurl}/incidents/#{id}"
+    url = "#{@baseurl}/chatopsincidents/#{id}"
     @.getResp(url, callback)
     @incident_id = id
 
   getlist: (callback) ->
-    url = "#{@baseurl}/incidents"
+    url = "#{@baseurl}/chatopsincidents"
     @.getResp(url, callback)
 
   create: (opts, callback = null) ->
-    url = "#{@baseurl}/incidents"
+    url = "#{@baseurl}/chatopsincidents"
     @.postResp(url, opts, callback)
 
   update: (opts, callback = null) ->
-    url = "#{@baseurl}/incidents/#{@incident_id}/action/update"
+    url = "#{@baseurl}/chatopsincidents/#{@incident_id}/action/update"
     @.postResp(url, opts, callback)
 
   close: (opts,callback=null)->
-    url = "#{@baseurl}/incidents/#{@incident_id}/action/close"
+    url = "#{@baseurl}/chatopsincidents/#{@incident_id}/action/close"
     @.postResp(url,opts,callback)
 
 

--- a/lib/sm-slack.coffee
+++ b/lib/sm-slack.coffee
@@ -26,7 +26,6 @@ class SmExt
     @robot = robot
     @apiToken = apiToken
     @botToken = botToken
-    @users={}
     this.listUsers()
       .then (r)->
         for member in r.members

--- a/lib/sm-slack.coffee
+++ b/lib/sm-slack.coffee
@@ -20,12 +20,22 @@ Querystring = require 'querystring'
 SlackApi = require './slack_web_api'
 Promise = require 'bluebird'
 _ = require 'lodash'
+_users={}
 class SmExt
   constructor: (robot, apiToken = process.env.SLACK_APP_TOKEN, botToken=process.env.HUBOT_SLACK_TOKEN)->
     @robot = robot
     @apiToken = apiToken
     @botToken = botToken
-
+    @users={}
+    this.listUsers()
+      .then (r)->
+        for member in r.members
+          if member.profile.email != null && member.profile.email != undefined
+            _users[member.name]=member.profile.email.toString()
+      .catch (r)->
+        robot.logger.info r
+        
+       
   formatRecord: (record)->
     fields = _.omitBy record, (v)->
       Array.isArray v
@@ -117,7 +127,21 @@ class SmExt
       channel: channelId
       timestamp: ts
     SlackApi.pins.add opts
-
-
-
+    
+  getUser:(name)->
+    opts=
+      token: @botToken
+      user:name
+    SlackApi.users.info opts
+    
+  listUsers: ()->
+    opts=
+      token: @botToken
+    SlackApi.users.list opts
+  
+  getEmailByName: (name)->
+    if _users.hasOwnProperty name
+      return _users[name]
+    return null
+           
 module.exports = SmExt


### PR DESCRIPTION
1. change the restfull url to a dedicate url incidents--->chatopsincidents will upload the unl soon
2.add a function getEmailByName, so we can assign a ticket to a slack user
3.add new interface create/assign/addactivity/resolve
4.command line and help implement for sm create/assign/addactivity/resolve