### PR TITLE
sm chat ops new feature implement

### DIFF
--- a/lib/SMUtil.coffee
+++ b/lib/SMUtil.coffee
@@ -82,24 +82,24 @@ class IncidentMangement extends RestMethod
     @incident_id = null
 
   get: (id, callback) ->
-    url = "#{@baseurl}/incidents/#{id}"
+    url = "#{@baseurl}/chatopsincidents/#{id}"
     @.getResp(url, callback)
     @incident_id = id
 
   getlist: (callback) ->
-    url = "#{@baseurl}/incidents"
+    url = "#{@baseurl}/chatopsincidents"
     @.getResp(url, callback)
 
   create: (opts, callback = null) ->
-    url = "#{@baseurl}/incidents"
+    url = "#{@baseurl}/chatopsincidents"
     @.postResp(url, opts, callback)
 
   update: (opts, callback = null) ->
-    url = "#{@baseurl}/incidents/#{@incident_id}/action/update"
+    url = "#{@baseurl}/chatopsincidents/#{@incident_id}/action/update"
     @.postResp(url, opts, callback)
 
   close: (opts,callback=null)->
-    url = "#{@baseurl}/incidents/#{@incident_id}/action/close"
+    url = "#{@baseurl}/chatopsincidents/#{@incident_id}/action/close"
     @.postResp(url,opts,callback)
 
 

--- a/lib/sm-slack.coffee
+++ b/lib/sm-slack.coffee
@@ -26,7 +26,6 @@ class SmExt
     @robot = robot
     @apiToken = apiToken
     @botToken = botToken
-    @users={}
     this.listUsers()
       .then (r)->
         for member in r.members

--- a/lib/sm-slack.coffee
+++ b/lib/sm-slack.coffee
@@ -127,12 +127,6 @@ class SmExt
       timestamp: ts
     SlackApi.pins.add opts
     
-  getUser:(name)->
-    opts=
-      token: @botToken
-      user:name
-    SlackApi.users.info opts
-    
   listUsers: ()->
     opts=
       token: @botToken

--- a/lib/sm-slack.coffee
+++ b/lib/sm-slack.coffee
@@ -20,12 +20,22 @@ Querystring = require 'querystring'
 SlackApi = require './slack_web_api'
 Promise = require 'bluebird'
 _ = require 'lodash'
+_users={}
 class SmExt
   constructor: (robot, apiToken = process.env.SLACK_APP_TOKEN, botToken=process.env.HUBOT_SLACK_TOKEN)->
     @robot = robot
     @apiToken = apiToken
     @botToken = botToken
-
+    @users={}
+    this.listUsers()
+      .then (r)->
+        for member in r.members
+          if member.profile.email != null && member.profile.email != undefined
+            _users[member.name]=member.profile.email.toString()
+      .catch (r)->
+        robot.logger.info r
+        
+       
   formatRecord: (record)->
     fields = _.omitBy record, (v)->
       Array.isArray v
@@ -117,7 +127,21 @@ class SmExt
       channel: channelId
       timestamp: ts
     SlackApi.pins.add opts
-
-
-
+    
+  getUser:(name)->
+    opts=
+      token: @botToken
+      user:name
+    SlackApi.users.info opts
+    
+  listUsers: ()->
+    opts=
+      token: @botToken
+    SlackApi.users.list opts
+  
+  getEmailByName: (name)->
+    if _users.hasOwnProperty name
+      return _users[name]
+    return null
+           
 module.exports = SmExt


### PR DESCRIPTION
@keke please help review
1. change the url to a dedicate url for chatops incidents -> chatopsincidents
2. add a new function getEmailByName to get email by slack name
3. sm new interface assign/resolve/addactiviy/create implement
4. new command implement for  assign/resolve/addactiviy/create 